### PR TITLE
Updates Guzzle version in composer.json file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require":{
         "php":">=5.3.1",
-        "guzzle/guzzle": "3.0.*@dev"
+        "guzzle/guzzle": "3.8.*"
     },
     "autoload":{
         "psr-0":{


### PR DESCRIPTION
The Guzzle version in `composer.json` is currently 3.0 but Guzzle is already at version 3.8
None of the test break when this is updated. Can the version be updated?
