### PR TITLE
Fix response checking on multi requests

### DIFF
--- a/src/Yubikey/ResponseCollection.php
+++ b/src/Yubikey/ResponseCollection.php
@@ -48,9 +48,10 @@ class ResponseCollection implements \Countable, \Iterator, \ArrayAccess
             return $response->success();
         } else {
             foreach ($this->responses as $response) {
-                if ($response->success() === false) {
+                if ($response->success() === false
+                    && $response->status !== Response::REPLAY_REQUEST) {
                     return false;
-                } else {
+                } elseif ($response->success()) {
                     $success = true;
                 }
             }


### PR DESCRIPTION
When querying multiple servers (that is -- all servers mode -- not first server mode), REPLAYED_REQUEST responses should be ignored as long as one server reports OK, because servers may contact each other before the client contacts them. (See http://forum.yubico.com/viewtopic.php?f=3&t=701)