### PR TITLE
set php 7.4 as minimum version (still used, although not actively supported)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require":{
-        "php":">=5.3.1"
+        "php":">=7.4"
     },
     "require-dev": {
         "phpunit/phpunit": "4.3.2",


### PR DESCRIPTION
makes sense security wise and allows updating PHPunit