### PR TITLE
replace deprecated `utf8_encode` with `mb_convert_encoding`

### DIFF
--- a/src/Yubikey/Validate.php
+++ b/src/Yubikey/Validate.php
@@ -248,7 +248,7 @@ class Validate
         }
 
         $query = http_build_query($data);
-        $query = utf8_encode(str_replace('%3A', ':', $query));
+        $query = mb_convert_encoding(str_replace('%3A', ':', $query), 'UTF-8', 'ISO-8859-1');
 
         $hash = preg_replace(
             '/\+/', '%2B',


### PR DESCRIPTION
[`utf8_encode()`](https://www.php.net/manual/en/function.utf8-encode.php) was deprecated in PHP 8.2.